### PR TITLE
Fix ask_gpt scope

### DIFF
--- a/Lumi.py
+++ b/Lumi.py
@@ -514,13 +514,11 @@ def mark_support_sent(chat_id: int):
     info["last_support"] = datetime.now(timezone.utc).isoformat()
     save_state()
 
-    # ================== OPENROUTER ==================
-    def language_preset(code: str) -> dict:
-        return LANGUAGE.get(code, LANGUAGE[DEFAULT_LANGUAGE])
 
-    def ask_gpt(prompt: str, language: str = DEFAULT_LANGUAGE) -> str:
-        preset = language_preset(language)
-        sysmsg = preset["system"]
+# ================== OPENROUTER ==================
+def ask_gpt(prompt: str, language: str = DEFAULT_LANGUAGE) -> str:
+    preset = language_preset(language)
+    sysmsg = preset["system"]
 
     if not OPENROUTER_KEY:
         return "API ключ OpenRouter не настроен. Проверь .env"


### PR DESCRIPTION
## Summary
- move the ask_gpt helper out of mark_support_sent so it remains accessible to message handlers

## Testing
- python -m compileall Lumi.py

------
https://chatgpt.com/codex/tasks/task_e_68cacdbc23e0832fb739aad6cabb8ffb