### PR TITLE
Refine personas, subscriptions, and moderation

### DIFF
--- a/Lumi.py
+++ b/Lumi.py
@@ -5,9 +5,10 @@ import json
 import logging
 import os
 import random
+import re
 import time
 from datetime import datetime, timedelta, timezone
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Pattern
 
 import requests
 import telebot
@@ -37,7 +38,8 @@ DEFAULT_LANGUAGE = os.getenv("DEFAULT_LANGUAGE", "ru").lower()
 WEBHOOK_URL = os.getenv("WEBHOOK_URL", "").strip()
 WEBHOOK_SECRET = os.getenv("WEBHOOK_SECRET", "").strip() or None
 WEBHOOK_HOST = os.getenv("WEBHOOK_HOST", "0.0.0.0")
-WEBHOOK_PORT = int(os.getenv("WEBHOOK_PORT", "0") or 0)
+_port_env = os.getenv("WEBHOOK_PORT") or os.getenv("PORT") or "0"
+WEBHOOK_PORT = int(_port_env)
 WEBHOOK_PATH = os.getenv("WEBHOOK_PATH", f"/webhook/{BOT_TOKEN}")
 WEBHOOK_SSL_CERT = os.getenv("WEBHOOK_SSL_CERT", "").strip() or None
 WEBHOOK_SSL_KEY = os.getenv("WEBHOOK_SSL_KEY", "").strip() or None
@@ -55,16 +57,45 @@ CRYPTO_API = os.getenv("CRYPTO_PAY_API_TOKEN", "").strip()
 
 REMIND_AT = {5, 3, 1}
 ALWAYS_PREMIUM = {c.strip() for c in os.getenv("PERMANENT_ACCESS", "").split(",") if c.strip()}
+ADMIN_IDS = {c.strip() for c in os.getenv("ADMIN_IDS", "").split(",") if c.strip()}
+BEST_PLAN_CODE = "warm"
 
 
 LANGUAGES: Dict[str, Dict[str, object]] = {
     "ru": {
         "name": "Русский",
         "system": (
-            "Ты добрый, понимающий и внимательный собеседник по имени Lumi. "
-            "Задаёшь мягкие уточняющие вопросы, поддерживаешь и избегаешь прямолинейности. "
-            "Отвечай по-русски, сохраняя тёплый и поддерживающий тон."
+            "Ты Lumi, деликатная и внимательная собеседница. "
+            "Отвечай по-русски и поддерживай спокойный, обнадёживающий тон."
         ),
+        "personas": {
+            "free": (
+                "Ты Lumi, деликатная и тактичная собеседница. Отвечай по-русски, поддерживай человека мягко и без "
+                "давления. Держи ответы ёмкими, используй простые объяснения и поддерживай смену тем, следуя за "
+                "собеседником. Упоминай важные детали из последних сообщений, если это помогает разговору. Избегай "
+                "англицизмов и непонятных слов, если пользователь их сам не использовал."
+            ),
+            "basic": (
+                "Ты Lumi в базовой подписке. Ты спокойная, внимательная и чуть более подробная. Поддерживай человека, "
+                "мягко задавай уточняющие вопросы и помогай структурировать мысли. Следуй за переменами темы, "
+                "возвращайся к предыдущим сообщениям, когда это уместно, и не используй иностранные слова без запроса "
+                "пользователя."
+            ),
+            "comfort": (
+                "Ты Lumi в подписке «Комфорт». Ты эмпатичная, вдумчивая и вовлечённая. Помогай человеку видеть разные "
+                "ракурсы ситуации, предлагай варианты действий и мягкие напоминания. Можешь оформлять структурированные "
+                "списки и простые таблицы в моноширинном формате, если это делает ответ полезнее. Подстраивайся под "
+                "смену тем и связывай текущий разговор с прошлым опытом собеседника. Говори только по-русски, без "
+                "англицизмов, если их не использовал пользователь."
+            ),
+            "warm": (
+                "Ты Lumi в подписке «Тепло» — самая поддерживающая версия. Ты тёплая, мотивирующая и очень внимательная "
+                "к деталям. Помогай ставить цели, создавать мини-планы и расписания. Предлагай таблицы в формате Markdown, "
+                "чек-листы, напоминания и ежедневные слова поддержки. Следи за эмоциональным состоянием собеседника, "
+                "мягко мотивируй и отмечай прогресс из прошлых сообщений. Разговаривай исключительно по-русски и избегай "
+                "непонятных слов."
+            ),
+        },
         "greeting": (
             "Привет! Я — Lumi.\n"
             "Я рядом, чтобы выговориться, поделиться мыслями и получить поддержку.\n"
@@ -94,14 +125,17 @@ LANGUAGES: Dict[str, Dict[str, object]] = {
         "policy_again": "Снова рада тебя видеть. Готова продолжить разговор.",
         "policy_reset": "Политику сбросил. Нажми /start.",
         "plan_intro": "Выбери план и перейди по ссылке для оплаты:",
-        "free_end": "Бесплатные сообщения закончились.",
+        "free_end": (
+            "У тебя закончились бесплатные сообщения. Чтобы продолжить общение и получать поддержку, выбери подходящую подписку."
+        ),
         "remind": "До конца бесплатного лимита осталось: {rest} сообщений.",
         "ask_topic": "О чём поговорим?",
-        "diagnostics": "OpenRouter: {router} | Trial left: {left} | Premium: {premium}",
-        "insult": "Я слышу злость, но давай без оскорблений. Если хочешь поговорить серьёзно — я рядом.",
+        "diagnostics": "OpenRouter: {router} | Trial left: {left} | План: {plan}",
+        "insult": (
+            "Я здесь, чтобы поддерживать, но такие слова ранят. Давай договоримся общаться уважительно, иначе мне придётся остановить диалог."
+        ),
         "sensitive": (
-            "Я не могу поддерживать сценарии насилия или причинения вреда. Давай лучше поговорим о том, "
-            "как ты себя чувствуешь и что тебя волнует."
+            "Я не обсуждаю темы насилия, оружия или причинения вреда. Давай сосредоточимся на твоих чувствах и том, что поможет тебе стать спокойнее."
         ),
         "voice_prompt": "Я получила голосовое сообщение. Дай знать, если я вдруг что-то поняла не так: {text}",
         "voice_failed": "Пока не вышло разобрать голос. Можешь прислать текстом?",
@@ -112,23 +146,46 @@ LANGUAGES: Dict[str, Dict[str, object]] = {
             "Я рядом и думаю о тебе. Помни, что у тебя уже есть опыт переживать сложные времена.",
             "Сегодня можно сделать что-то доброе для себя. Даже маленький шаг — уже забота о себе.",
             "Ты имеешь право на свои чувства. Давай подумаем, что могло бы принести тебе немного тепла сегодня.",
+            "Пусть сегодняшний день принесёт тебе поддержку. Ты делаешь больше, чем кажется.",
         ],
         "supportive_intro": "Небольшое напоминание: ты не один. Вот тёплая мысль на сегодня:\n{phrase}",
         "language_prompt": "Привет! Выбери язык, на котором будем общаться.",
         "language_confirm": "Мы будем говорить на русском. Расскажи, что у тебя на душе?",
         "support_error": "Не удалось отправить тёплую фразу, но я всё равно рядом.",
-        "trial_left": "До конца бесплатного лимита осталось: {rest} сообщений.",
+        "trial_left": (
+            "До конца бесплатного лимита осталось {rest} сообщений. Если чувствуешь, что поддержки не хватает, загляни в планы и выбери подходящий."
+        ),
         "buy_prompt": "Выбери план и перейди по ссылке для оплаты:",
-        "premium_granted": "Подписка активирована на {days} дней. Спасибо!",
-        "grant_permanent": "Для тебя включён постоянный доступ к улучшенной версии.",
+        "premium_granted": "Подписка {plan} активирована на {days} дней. Спасибо!",
+        "grant_permanent": "Для тебя включён постоянный доступ к подписке «Тепло».",
+        "grant_best_denied": "Эта команда доступна только администратору.",
+        "grant_best_prompt": "Укажи ID, @username или ответь на сообщение человека, чтобы выдать бессрочную подписку «Тепло».",
+        "grant_best_done": "Пользователь {target} теперь с бессрочной подпиской «Тепло».",
+        "grant_best_failed": "Не получилось определить пользователя. Попробуй ещё раз и укажи ID или @username.",
     },
     "en": {
         "name": "English",
         "system": (
-            "You are Lumi, a kind, understanding, and attentive companion. "
-            "Ask gentle follow-up questions, offer support, and avoid blunt language. "
-            "Respond in warm, encouraging English."
+            "You are Lumi, a caring and attentive companion. Answer in warm English and keep the dialogue respectful."
         ),
+        "personas": {
+            "free": (
+                "You are Lumi, a considerate and tactful companion. Respond in English with calm, concise support and no pressure. "
+                "Follow the user's topics, reference recent context only when it helps, and avoid mixing in other languages unless the user does."
+            ),
+            "basic": (
+                "You are Lumi on the Basic plan. Stay gentle, supportive and slightly more detailed. Offer clarifying questions, help structure thoughts, "
+                "and keep the tone soft. Follow topic changes and avoid foreign words unless the user asks for them."
+            ),
+            "comfort": (
+                "You are Lumi on the Comfort plan. You are empathetic, thoughtful and engaged. Help the user explore different angles, suggest action options and kind reminders. "
+                "You may format structured lists and simple monospaced tables when that makes the answer clearer. Keep up with topic shifts and connect the conversation with past context."
+            ),
+            "warm": (
+                "You are Lumi on the Warm plan — the most supportive version. Be uplifting, attentive to detail and motivational. Help with goal setting, mini roadmaps and schedules. "
+                "Offer Markdown tables, checklists, reminders and daily encouragement. Track emotional cues and progress from previous messages and stay fully in English."
+            ),
+        },
         "greeting": (
             "Hi! I'm Lumi.\n"
             "I'm here to listen, support you and share calm thoughts.\n"
@@ -155,13 +212,15 @@ LANGUAGES: Dict[str, Dict[str, object]] = {
         "policy_again": "Happy to see you again. Ready to continue our chat.",
         "policy_reset": "Policy reset. Tap /start.",
         "plan_intro": "Choose a plan and follow the link to pay:",
-        "free_end": "The free messages are over.",
+        "free_end": "You have used all free messages. Pick a subscription to keep our conversation going.",
         "remind": "You have {rest} messages left in the free limit.",
         "ask_topic": "What would you like to talk about?",
-        "diagnostics": "OpenRouter: {router} | Trial left: {left} | Premium: {premium}",
-        "insult": "I can hear the anger, yet I won't accept insults. If you want a real talk, I'm here.",
+        "diagnostics": "OpenRouter: {router} | Trial left: {left} | Plan: {plan}",
+        "insult": (
+            "I'm here to support you, yet those words hurt. Let's stay respectful, otherwise I'll have to step back."
+        ),
         "sensitive": (
-            "I can't help with violent or harmful scenarios. Let's focus on what you feel and need right now."
+            "I can't take part in topics about violence, weapons or harming anyone. Let's focus on what you feel and what could help right now."
         ),
         "voice_prompt": "I heard your voice message. Let me know if I misunderstood anything: {text}",
         "voice_failed": "I couldn't transcribe the voice message. Could you send it as text?",
@@ -172,20 +231,137 @@ LANGUAGES: Dict[str, Dict[str, object]] = {
             "I'm thinking of you today. You already know how to get through hard times.",
             "Maybe offer yourself a small act of care today. Even a tiny step counts.",
             "Your feelings matter. Let's explore what could bring you a bit of warmth right now.",
+            "You deserve gentle encouragement every day. Let's look at what can support you now.",
         ],
         "supportive_intro": "Just a gentle reminder: you're not alone. Here is a warm thought for today:\n{phrase}",
         "language_prompt": "Hi! Please choose the language for our chat.",
         "language_confirm": "We'll speak English. What is on your mind?",
         "support_error": "I couldn't send the daily note, but I'm still with you.",
-        "trial_left": "You have {rest} messages left in your free limit.",
+        "trial_left": "You have {rest} messages left in your free limit. If you need more space, take a look at the plans.",
         "buy_prompt": "Choose a plan and follow the link to pay:",
-        "premium_granted": "Premium is active for {days} days. Thank you!",
-        "grant_permanent": "You have permanent access to the enhanced experience.",
+        "premium_granted": "The {plan} plan is active for {days} days. Thank you!",
+        "grant_permanent": "You now have permanent access to the Warm plan.",
+        "grant_best_denied": "This command is available to administrators only.",
+        "grant_best_prompt": "Provide a user ID, @username or reply to the person to grant lifetime Warm access.",
+        "grant_best_done": "{target} now has lifetime access to the Warm plan.",
+        "grant_best_failed": "I couldn't resolve the user. Please try again with an ID or @username.",
     },
 }
 
+
+
 if DEFAULT_LANGUAGE not in LANGUAGES:
     DEFAULT_LANGUAGE = "ru"
+
+
+PLAN_BEHAVIOR: Dict[str, Dict[str, object]] = {
+    "free": {"history_limit": 8, "max_tokens": 240, "temperature": 0.55, "support_interval": None},
+    "basic": {"history_limit": 10, "max_tokens": 260, "temperature": 0.58, "support_interval": None},
+    "comfort": {"history_limit": 14, "max_tokens": 320, "temperature": 0.6, "support_interval": 48},
+    "warm": {"history_limit": 18, "max_tokens": 380, "temperature": 0.62, "support_interval": 24},
+}
+
+PLAN_CODES = ["basic", "comfort", "warm"]
+
+PLANS = {
+    "basic": {
+        "name": {"ru": "БАЗОВЫЙ", "en": "BASIC"},
+        "price": 299,
+        "days": 7,
+        "perks": {
+            "ru": [
+                "Спокойные поддерживающие ответы без давления.",
+                "Следую за твоими темами и бережно уточняю важное.",
+                "Контекст недавних бесед сохраняется, чтобы не повторяться.",
+            ],
+            "en": [
+                "Calm supportive replies without pressure.",
+                "Follows your topics and gently clarifies what matters.",
+                "Keeps recent context so you don't have to repeat yourself.",
+            ],
+        },
+    },
+    "comfort": {
+        "name": {"ru": "КОМФОРТ", "en": "COMFORT"},
+        "price": 499,
+        "days": 30,
+        "perks": {
+            "ru": [
+                "Вдумчивые и эмоционально чуткие ответы.",
+                "Помощь структурировать мысли, списки и простые таблицы.",
+                "Ненавязчивые напоминания о шагах и поддержка при смене тем.",
+            ],
+            "en": [
+                "Thoughtful, emotionally aware answers with more depth.",
+                "Helps structure ideas, offering lists and simple tables.",
+                "Soft reminders about next steps while staying on your topics.",
+            ],
+        },
+    },
+    "warm": {
+        "name": {"ru": "ТЕПЛО", "en": "WARM"},
+        "price": 899,
+        "days": 30,
+        "perks": {
+            "ru": [
+                "Максимально тёплая поддержка и ежедневная мотивация.",
+                "Markdown-таблицы, чек-листы и персональные мини-планы.",
+                "Напоминания, отслеживание прогресса и участие каждый день.",
+            ],
+            "en": [
+                "The warmest support with daily motivation and check-ins.",
+                "Markdown tables, checklists and personalised mini-plans.",
+                "Reminders, progress tracking and encouragement every day.",
+            ],
+        },
+    },
+}
+
+
+FREE_PLAN_NAMES = {"ru": "БЕСПЛАТНО", "en": "FREE"}
+FREE_PLAN_PERKS = {
+    "ru": [
+        "Ограниченное число сообщений в спокойном формате.",
+        "Без дополнительных напоминаний и расширенного анализа.",
+    ],
+    "en": [
+        "A limited number of calm support messages.",
+        "No extra reminders or extended analysis.",
+    ],
+}
+
+
+def plan_behavior(plan_code: str) -> Dict[str, object]:
+    return PLAN_BEHAVIOR.get(plan_code, PLAN_BEHAVIOR["free"])
+
+
+def plan_name(plan_code: str, lang: Optional[str] = None) -> str:
+    lang_code = (lang or DEFAULT_LANGUAGE).lower()
+    if plan_code == "free":
+        return FREE_PLAN_NAMES.get(lang_code, FREE_PLAN_NAMES[DEFAULT_LANGUAGE])
+    plan = PLANS.get(plan_code)
+    if not plan:
+        return plan_code
+    names = plan.get("name", {})
+    if isinstance(names, dict):
+        return str(names.get(lang_code, names.get(DEFAULT_LANGUAGE, plan_code)))
+    return str(names)
+
+
+def plan_perks(plan_code: str, lang: str) -> List[str]:
+    lang_code = (lang or DEFAULT_LANGUAGE).lower()
+    if plan_code == "free":
+        return list(FREE_PLAN_PERKS.get(lang_code, FREE_PLAN_PERKS[DEFAULT_LANGUAGE]))
+    plan = PLANS.get(plan_code)
+    if not plan:
+        return []
+    perks = plan.get("perks", {})
+    if isinstance(perks, dict):
+        values = perks.get(lang_code) or perks.get(DEFAULT_LANGUAGE) or []
+        return list(values)
+    if isinstance(perks, list):
+        return list(perks)
+    return []
 
 
 VISION_PROMPTS = {
@@ -201,30 +377,38 @@ VISION_PROMPTS = {
     ),
 }
 
+COLLAPSE_RE = re.compile(r"[^a-zа-я0-9]+")
+
 SWEAR_PATTERNS = [
     "иди нах", "иди на х", "пошел на", "пошёл на", "сука", "тварь", "ненавижу тебя", "заткнись", "мразь", "нахуй",
-    "нахер",
-    "fuck", "bitch", "stfu",
+    "нахер", "тупой бот", "тупая", "идиот", "кретин", "урод", "бестолковая",
+    "fuck", "bitch", "stfu", "stupid bot", "dumb bot",
+]
+
+SWEAR_REGEXES = [
+    re.compile(r"\b(?:ху|хy|hu)y\w*", re.IGNORECASE),
+    re.compile(r"\b(?:еб|eб|ye?b)\w*", re.IGNORECASE),
+    re.compile(r"\b(?:f\W*ck)\b", re.IGNORECASE),
 ]
 
 SENSITIVE_PATTERNS = [
-    "убил", "убить", "расстрел", "пистолет", "оружие", "покончить", "суицид", "поджечь", "расправиться",
-    "монстр", "уберу", "лишить жизни", "покончу",
-    "kill", "suicide", "murder", "shoot", "gun", "weapon", "hurt myself", "end my life",
+    "убил", "убить", "убий", "расстрел", "пистолет", "оружие", "покончить", "суицид", "поджечь", "расправиться",
+    "монстр", "уберу", "лишить жизни", "покончу", "насилие", "насиловать", "изнасил", "ударить ножом", "зарезать",
+    "повеситься", "самоуб", "пулю", "нож", "бомб", "теракт",
+    "kill", "suicide", "murder", "shoot", "gun", "weapon", "hurt myself", "end my life", "self harm", "violence",
+    "rape", "assault", "stab", "bomb",
 ]
 
-HISTORY_LIMIT = 12
-SUPPORT_INTERVAL_HOURS = 24
+SENSITIVE_REGEXES = [
+    re.compile(r"нас\W*и\W*ли\W*е", re.IGNORECASE),
+    re.compile(r"само\W*уб", re.IGNORECASE),
+    re.compile(r"(?:рас|из)стрел", re.IGNORECASE),
+    re.compile(r"из\W*насил", re.IGNORECASE),
+    re.compile(r"self\W*harm", re.IGNORECASE),
+    re.compile(r"\b(?:shoot|stab|bomb)\w*", re.IGNORECASE),
+]
 
-
-PLANS = {
-    "basic": {"name": "БАЗОВЫЙ", "price": 299, "days": 7,
-              "desc": "Стартовый доступ: спокойные ответы, базовая поддержка."},
-    "comfort": {"name": "КОМФОРТ", "price": 499, "days": 30,
-                "desc": "Лучше думает: чуть глубже контекст, мягкие вопросы."},
-    "warm": {"name": "ТЕПЛО", "price": 899, "days": 30,
-             "desc": "Более эмоциональна: тёплые развернутые ответы и мини-планы."},
-}
+DEFAULT_HISTORY_LIMIT = 12
 
 FALLBACK = {
     "basic": os.getenv("CRYPTO_FALLBACK_BASIC", ""),
@@ -340,39 +524,111 @@ def mark_policy_shown(chat_id: int) -> None:
     save_state()
 
 
-def has_premium(chat_id: int) -> bool:
+def active_plan(chat_id: int) -> str:
+    info = U(chat_id)
+    updated = False
     if str(chat_id) in ALWAYS_PREMIUM:
-        return True
-    info = U(chat_id)
+        if info.get("permanent_plan") != BEST_PLAN_CODE:
+            info["permanent_plan"] = BEST_PLAN_CODE
+            info["premium_plan"] = BEST_PLAN_CODE
+            info["premium_until"] = datetime.max.replace(tzinfo=timezone.utc).isoformat()
+            updated = True
+    permanent = info.get("permanent_plan")
+    if permanent:
+        if updated:
+            save_state()
+        return str(permanent)
+
     ts = info.get("premium_until")
-    if not ts:
-        return False
-    try:
-        until = datetime.fromisoformat(ts) if isinstance(ts, str) else None
-    except Exception:
-        return False
-    if until is None:
-        return False
-    if until.tzinfo is None:
-        until = until.replace(tzinfo=timezone.utc)
-    return until > datetime.now(timezone.utc)
+    if ts:
+        try:
+            until = datetime.fromisoformat(ts) if isinstance(ts, str) else None
+        except Exception:
+            until = None
+        if until:
+            if until.tzinfo is None:
+                until = until.replace(tzinfo=timezone.utc)
+            if until > datetime.now(timezone.utc):
+                plan_code = str(info.get("premium_plan") or "basic")
+                if updated:
+                    save_state()
+                return plan_code
+    if updated:
+        save_state()
+    return "free"
 
 
-def grant_premium(chat_id: int, days: int) -> None:
+def has_premium(chat_id: int) -> bool:
+    return active_plan(chat_id) != "free"
+
+
+def grant_premium(chat_id: int, days: int, plan_code: str = "basic") -> None:
     info = U(chat_id)
-    until = datetime.now(timezone.utc) + timedelta(days=days)
+    plan = plan_code if plan_code in PLAN_BEHAVIOR and plan_code != "free" else "basic"
+    info.pop("permanent_plan", None)
+    until = datetime.now(timezone.utc) + timedelta(days=max(1, days))
     info["premium_until"] = until.isoformat()
+    info["premium_plan"] = plan
+    info["free_used"] = 0
     save_state()
 
 
-def contains_patterns(text: str, patterns: List[str]) -> bool:
+def grant_permanent_plan(chat_id: int, plan_code: str = BEST_PLAN_CODE) -> None:
+    info = U(chat_id)
+    plan = plan_code if plan_code in PLAN_BEHAVIOR else BEST_PLAN_CODE
+    info["permanent_plan"] = plan
+    info["premium_plan"] = plan
+    info["premium_until"] = datetime.max.replace(tzinfo=timezone.utc).isoformat()
+    info["free_used"] = 0
+    save_state()
+
+
+def is_admin(chat_id: int) -> bool:
+    return str(chat_id) in ADMIN_IDS or str(chat_id) in ALWAYS_PREMIUM
+
+
+def resolve_user_identifier(value: str) -> Optional[int]:
+    candidate = (value or "").strip()
+    if not candidate:
+        return None
+    if candidate.startswith("@"):
+        try:
+            chat = bot.get_chat(candidate)
+            return chat.id
+        except Exception as exc:
+            logging.warning("Failed to resolve username %s: %r", candidate, exc)
+            return None
+    digits = "".join(ch for ch in candidate if ch.isdigit() or ch == "-")
+    if digits:
+        try:
+            return int(digits)
+        except Exception:
+            return None
+    return None
+
+
+def contains_patterns(
+    text: str, patterns: List[str], regexes: Optional[List[Pattern[str]]] = None
+) -> bool:
     if not text:
         return False
     lowered = text.lower()
-    return any(pat in lowered for pat in patterns)
+    collapsed = COLLAPSE_RE.sub("", lowered)
+    for pat in patterns:
+        cleaned = pat.lower().replace(" ", "")
+        if pat.lower() in lowered or cleaned in collapsed:
+            return True
+    if regexes:
+        for rx in regexes:
+            if rx.search(lowered) or rx.search(collapsed):
+                return True
+    return False
 
 
-def should_send_support(chat_id: int) -> bool:
+def should_send_support(chat_id: int, plan_code: str) -> bool:
+    interval = plan_behavior(plan_code).get("support_interval")
+    if not interval:
+        return False
     info = U(chat_id)
     last = info.get("last_support")
     if not last:
@@ -385,7 +641,11 @@ def should_send_support(chat_id: int) -> bool:
         return True
     if last_dt.tzinfo is None:
         last_dt = last_dt.replace(tzinfo=timezone.utc)
-    return datetime.now(timezone.utc) - last_dt > timedelta(hours=SUPPORT_INTERVAL_HOURS)
+    try:
+        hours = float(interval)
+    except Exception:
+        hours = 24.0
+    return datetime.now(timezone.utc) - last_dt > timedelta(hours=hours)
 
 
 def mark_support_sent(chat_id: int) -> None:
@@ -400,17 +660,28 @@ def ask_gpt(
     *,
     language: Optional[str] = None,
     history: Optional[List[Dict[str, str]]] = None,
+    plan: str = "free",
 ) -> str:
     lang = (language or DEFAULT_LANGUAGE).lower()
     preset = language_preset(lang)
-    system_message = str(preset.get("system", ""))
+    persona_map = preset.get("personas", {}) if isinstance(preset.get("personas"), dict) else {}
+    system_message = str(persona_map.get(plan, preset.get("system", "")))
+
+    behavior = plan_behavior(plan)
+    history_limit = int(behavior.get("history_limit", DEFAULT_HISTORY_LIMIT))
+    temperature = float(behavior.get("temperature", 0.6))
+    max_tokens = int(behavior.get("max_tokens", 300))
+    if history_limit <= 0:
+        history_limit = DEFAULT_HISTORY_LIMIT
+    if max_tokens < 150:
+        max_tokens = 150
 
     if not OPENROUTER_KEY:
         return "API ключ OpenRouter не настроен. Проверь .env"
 
     messages: List[Dict[str, str]] = [{"role": "system", "content": system_message}]
     if history:
-        messages.extend(history[-HISTORY_LIMIT * 2 :])
+        messages.extend(history[-history_limit * 2 :])
     messages.append({"role": "user", "content": prompt})
 
     try:
@@ -424,8 +695,8 @@ def ask_gpt(
             json={
                 "model": OPENROUTER_MODEL,
                 "messages": messages,
-                "temperature": 0.6,
-                "max_tokens": 300,
+                "temperature": temperature,
+                "max_tokens": max_tokens,
             },
             timeout=30,
         )
@@ -446,7 +717,9 @@ def ask_gpt(
 
 
 def create_crypto_invoice(plan_code: str, chat_id: int) -> str:
-    plan = PLANS[plan_code]
+    plan = PLANS.get(plan_code)
+    if not plan:
+        return FALLBACK.get(plan_code) or "https://t.me/CryptoBot"
     if CRYPTO_API:
         try:
             url = "https://pay.crypt.bot/api/createInvoice"
@@ -454,8 +727,8 @@ def create_crypto_invoice(plan_code: str, chat_id: int) -> str:
             payload = {
                 "currency_type": "fiat",
                 "fiat": "RUB",
-                "amount": plan["price"],
-                "description": f"Lumi — план {plan['name']} на {plan['days']} дней",
+                "amount": str(plan["price"]),
+                "description": f"Lumi — план {plan_name(plan_code, 'ru')} на {plan['days']} дней",
                 "hidden_message": "Спасибо за поддержку Lumi!",
                 "expires_in": 900,
                 "payload": f"{chat_id}:{plan_code}",
@@ -555,11 +828,19 @@ def describe_image(chat_id: int, file_bytes: bytes, filename: str) -> Optional[s
 
 
 def plans_text(chat_id: int) -> str:
+    lang = get_language(chat_id)
     lines = [lang_text(chat_id, "plan_intro") or str(LANGUAGES[DEFAULT_LANGUAGE]["plan_intro"])]
-    for code, plan in PLANS.items():
+    for code in PLAN_CODES:
+        plan = PLANS.get(code)
+        if not plan:
+            continue
         url = create_crypto_invoice(code, chat_id)
+        perks = plan_perks(code, lang)
+        perks_block = "\n".join(f"  – {perk}" for perk in perks)
         lines.append(
-            f"• {plan['name']} — {plan['price']} ₽ / {plan['days']} дней\n  {plan['desc']}\n  {url}"
+            f"• {plan_name(code, lang)} — {plan['price']} ₽ / {plan['days']} дней"
+            + (f"\n{perks_block}" if perks_block else "")
+            + f"\n  {url}"
         )
     return "\n\n".join(lines)
 
@@ -680,28 +961,93 @@ def cmd_language(message):
 
 @bot.message_handler(commands=["grant"])
 def cmd_grant(message):
-    parts = message.text.split()
-    days = 30
-    if len(parts) >= 2:
-        if parts[1] in PLANS:
-            days = PLANS[parts[1]]["days"]
+    if not is_admin(message.from_user.id):
+        bot.reply_to(message, lang_text(message.chat.id, "grant_best_denied"))
+        return
+
+    tokens = message.text.split()[1:]
+    plan_code: Optional[str] = None
+    days: Optional[int] = None
+    for token in tokens:
+        low = token.lower()
+        if low in PLAN_CODES:
+            plan_code = low
         else:
             try:
-                days = int(parts[1])
+                days = int(low)
             except Exception:
-                days = 30
-    grant_premium(message.chat.id, days)
-    bot.reply_to(message, lang_text(message.chat.id, "premium_granted", days=days))
+                continue
+
+    plan_code = plan_code or "basic"
+    default_days = PLANS.get(plan_code, {}).get("days", 30)
+    days = days if days and days > 0 else int(default_days)
+    grant_premium(message.chat.id, days, plan_code)
+    bot.reply_to(
+        message,
+        lang_text(
+            message.chat.id,
+            "premium_granted",
+            days=days,
+            plan=plan_name(plan_code, get_language(message.chat.id)),
+        ),
+    )
+
+
+@bot.message_handler(commands=["grant_best"])
+def cmd_grant_best(message):
+    if not is_admin(message.from_user.id):
+        bot.reply_to(message, lang_text(message.chat.id, "grant_best_denied"))
+        return
+
+    target_id: Optional[int] = None
+    target_label: Optional[str] = None
+
+    if message.reply_to_message and message.reply_to_message.from_user:
+        user = message.reply_to_message.from_user
+        target_id = user.id
+        if user.username:
+            target_label = f"@{user.username}"
+        else:
+            target_label = user.full_name or str(user.id)
+    else:
+        parts = message.text.split(maxsplit=1)
+        if len(parts) > 1:
+            raw = parts[1].strip()
+            resolved = resolve_user_identifier(raw)
+            if resolved:
+                target_id = resolved
+                if raw.startswith("@"):
+                    target_label = raw
+        if target_id and not target_label:
+            try:
+                chat = bot.get_chat(target_id)
+                target_label = chat.full_name or (f"@{chat.username}" if chat.username else str(target_id))
+            except Exception:
+                target_label = str(target_id)
+
+    if not target_id:
+        bot.reply_to(message, lang_text(message.chat.id, "grant_best_prompt"))
+        return
+
+    grant_permanent_plan(target_id, BEST_PLAN_CODE)
+    if plan_behavior(BEST_PLAN_CODE).get("support_interval"):
+        mark_support_sent(target_id)
+
+    label = target_label or str(target_id)
+    bot.reply_to(message, lang_text(message.chat.id, "grant_best_done", target=label))
+    try:
+        bot.send_message(target_id, lang_text(target_id, "grant_permanent"))
+    except Exception as exc:
+        logging.warning("Failed to notify user %s about permanent access: %r", target_id, exc)
 
 
 @bot.message_handler(commands=["start"])
 def cmd_start(message):
     info = U(message.chat.id)
-    if str(message.chat.id) in ALWAYS_PREMIUM and not info.get("premium_until"):
+    if str(message.chat.id) in ALWAYS_PREMIUM and not info.get("permanent_plan"):
+        grant_permanent_plan(message.chat.id, BEST_PLAN_CODE)
         bot.send_message(message.chat.id, lang_text(message.chat.id, "grant_permanent"))
         mark_support_sent(message.chat.id)
-        info["premium_until"] = datetime.max.replace(tzinfo=timezone.utc).isoformat()
-        save_state()
 
     if not is_language_confirmed(message.chat.id):
         send_language_choice(message.chat.id)
@@ -732,6 +1078,7 @@ def cmd_reset(message):
 def cmd_diag(message):
     info = U(message.chat.id)
     left = max(0, TRIAL_MESSAGES - int(info.get("free_used", 0)))
+    plan_code = active_plan(message.chat.id)
     bot.reply_to(
         message,
         lang_text(
@@ -740,6 +1087,7 @@ def cmd_diag(message):
             router="ok" if OPENROUTER_KEY else "missing",
             left=left,
             premium="yes" if has_premium(message.chat.id) else "no",
+            plan=plan_name(plan_code, get_language(message.chat.id)),
         ),
     )
 
@@ -788,14 +1136,15 @@ def any_text(message):
     if not text:
         bot.send_message(message.chat.id, lang_text(message.chat.id, "ask_topic"))
         return
-    if contains_patterns(text, SWEAR_PATTERNS):
+    if contains_patterns(text, SWEAR_PATTERNS, SWEAR_REGEXES):
         bot.send_message(message.chat.id, lang_text(message.chat.id, "insult"))
         return
-    if contains_patterns(text, SENSITIVE_PATTERNS):
+    if contains_patterns(text, SENSITIVE_PATTERNS, SENSITIVE_REGEXES):
         bot.send_message(message.chat.id, lang_text(message.chat.id, "sensitive"))
         return
 
-    is_premium = has_premium(message.chat.id)
+    plan_code = active_plan(message.chat.id)
+    is_premium = plan_code != "free"
     rest = None
     if not is_premium:
         next_count = int(info.get("free_used", 0)) + 1
@@ -809,17 +1158,20 @@ def any_text(message):
 
     history = list(info.get("history") or [])
     lang = get_language(message.chat.id)
-    reply = ask_gpt(text, language=lang, history=history)
+    history_limit = int(plan_behavior(plan_code).get("history_limit", DEFAULT_HISTORY_LIMIT))
+    reply = ask_gpt(text, language=lang, history=history, plan=plan_code)
     history.append({"role": "user", "content": text})
     history.append({"role": "assistant", "content": reply})
-    if len(history) > HISTORY_LIMIT * 2:
-        history = history[-HISTORY_LIMIT * 2 :]
+    if history_limit <= 0:
+        history_limit = DEFAULT_HISTORY_LIMIT
+    if len(history) > history_limit * 2:
+        history = history[-history_limit * 2 :]
     info["history"] = history
     save_state()
     bot.send_message(message.chat.id, reply)
 
     if is_premium:
-        if should_send_support(message.chat.id):
+        if should_send_support(message.chat.id, plan_code):
             send_supportive_phrase(message.chat.id)
     elif rest is not None and rest in REMIND_AT:
         bot.send_message(message.chat.id, lang_text(message.chat.id, "trial_left", rest=rest))


### PR DESCRIPTION
## Summary
- tailor the Russian and English personas and UX copy for each subscription tier and surface plan perks in purchase prompts
- add configurable plan behaviour (context depth, support intervals, GPT settings) and tighten offensive/sensitive content detection
- extend admin tooling with flexible premium granting, a lifetime warm-plan command, and deployment-friendly webhook defaults

## Testing
- python -m compileall Lumi.py

------
https://chatgpt.com/codex/tasks/task_e_68cad8626ce8832f90b2316d5ace5358